### PR TITLE
add w3c validation compatibility

### DIFF
--- a/src/fm-timepicker.js
+++ b/src/fm-timepicker.js
@@ -278,7 +278,7 @@
 					           "  </div>" +
 					           "</div>",
 					replace  : true,
-					restrict : "E",
+					restrict : "EA",
 					scope    : {
 						ngModel       : "=",
 						format        : "=?",


### PR DESCRIPTION
This commit allows the usage of the timepicker directive as an attribute in order to make it W3C-valid.
Currently HTML does not allow custom elements, custom attributes, however, validate fine if they are prepended by 'data-'. Since Angular also picks up directives that come with a data-prefix fm-timepicker can thus be used in a W3C-valid way (when necessary) like so:
```html
<div data-fm-timepicker data-ng-model="..." data-format="'HH:mm' ...></div>
```