### PR TITLE
fixed bug that occurs when no reference is specified and scope.refere…

### DIFF
--- a/src/fm-timepicker.js
+++ b/src/fm-timepicker.js
@@ -565,7 +565,7 @@
 						scope.select = function( timestamp, elementIndex ) {
 							// Construct a moment instance from the UNIX offset.
 							var time;
-							if( moment.tz ) {
+							if( moment.tz && scope.reference.tz() ) {
 								time = moment( timestamp ).tz( scope.reference.tz() );
 							} else {
 								time = moment( timestamp );


### PR DESCRIPTION
This commit fixes a bug when no reference is given.
( scope.reference.tz() evaluates to undefined in that case )